### PR TITLE
Create PHP web app for generating energy reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/data/*.db
+/.DS_Store
+/vendor/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
 # Centralis
+
 Backbone For Small Business Apps
 
-## Database setup
+## Requirements
 
-Create the tables:
+- PHP 8.1+
+- SQLite3
+
+## Getting started
+
+1. Install dependencies (PHP and SQLite must be available on your machine).
+2. Create the SQLite database and seed it with example data:
 
 ```bash
-sqlite3 path/to/centralis.db < database/schema.sql
+mkdir -p data
+sqlite3 data/centralis.db < database/schema.sql
+sqlite3 data/centralis.db < database/seed.sql
 ```
 
-Load example data:
+3. Start the PHP development server:
 
 ```bash
-sqlite3 path/to/centralis.db < database/seed.sql
+php -S localhost:8000 -t public
 ```
+
+4. Visit [http://localhost:8000](http://localhost:8000) in your browser to create new reports or view existing ones.
+
+## Project structure
+
+```
+├── database
+│   ├── schema.sql        # Database schema
+│   └── seed.sql          # Sample data that mirrors the example report
+├── includes
+│   ├── db.php            # Database bootstrap
+│   └── helpers.php       # Formatting helpers shared by the views
+├── public
+│   ├── css
+│   │   └── style.css     # Application styling
+│   ├── create_report.php # Data entry form for new reports
+│   ├── index.php         # Lists existing reports
+│   └── report.php        # Printable report view
+└── README.md
+```
+
+The report view mirrors the structure of the original Word mail merge output and can be printed or saved as a PDF using the browser's print dialog.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,21 +1,50 @@
-CREATE TABLE company (
+DROP TABLE IF EXISTS other_costs;
+DROP TABLE IF EXISTS contract_offers;
+DROP TABLE IF EXISTS reports;
+
+CREATE TABLE reports (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    company_name TEXT,
-    abn TEXT,
-    nmi_mirn TEXT,
-    site_address TEXT,
-    suburb TEXT,
-    postcode TEXT
+    report_identifier TEXT NOT NULL,
+    report_date TEXT,
+    customer_business_name TEXT NOT NULL,
+    customer_contact_name TEXT,
+    broker_consultant TEXT,
+    site_nmi TEXT,
+    site_current_retailer TEXT,
+    site_contract_end_date TEXT,
+    site_address_line1 TEXT,
+    site_address_line2 TEXT,
+    site_peak_kwh REAL,
+    site_shoulder_kwh REAL,
+    site_off_peak_kwh REAL,
+    site_total_kwh REAL,
+    contract_current_retailer TEXT,
+    contract_term_months INTEGER,
+    current_cost REAL,
+    new_cost REAL,
+    validity_period TEXT,
+    payment_terms TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE invoice (
-    company_id INTEGER NOT NULL,
-    period TEXT,
-    nmi_number TEXT,
-    location2 TEXT,
-    invoice TEXT,
-    ex_gst REAL,
-    gst REAL,
-    total REAL,
-    FOREIGN KEY (company_id) REFERENCES company(id)
+CREATE TABLE contract_offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    report_id INTEGER NOT NULL,
+    supplier_name TEXT NOT NULL,
+    term_months INTEGER NOT NULL,
+    peak_rate REAL,
+    shoulder_rate REAL,
+    off_peak_rate REAL,
+    total_cost REAL,
+    diff_dollar REAL,
+    diff_percentage REAL,
+    FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE
+);
+
+CREATE TABLE other_costs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    report_id INTEGER NOT NULL,
+    cost_label TEXT NOT NULL,
+    cost_amount REAL NOT NULL,
+    FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE
 );

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,9 +1,69 @@
--- Example data for Centralis schema
-INSERT INTO company (company_name, abn, nmi_mirn, site_address, suburb, postcode) VALUES
-  ('Acme Pty Ltd', '12345678901', 'NMI123', '1 Main St', 'Sydney', '2000'),
-  ('Globex Corporation', '98765432109', 'NMI987', '42 Enterprise Rd', 'Melbourne', '3000');
+INSERT INTO reports (
+    report_identifier,
+    report_date,
+    customer_business_name,
+    customer_contact_name,
+    broker_consultant,
+    site_nmi,
+    site_current_retailer,
+    site_contract_end_date,
+    site_address_line1,
+    site_address_line2,
+    site_peak_kwh,
+    site_shoulder_kwh,
+    site_off_peak_kwh,
+    site_total_kwh,
+    contract_current_retailer,
+    contract_term_months,
+    current_cost,
+    new_cost,
+    validity_period,
+    payment_terms
+) VALUES (
+    '146',
+    '2025-09-25',
+    'Discover 202 Pty Ltd',
+    'Nelsy Zreik',
+    'Alex Dechnicz',
+    '41039619655',
+    'Momentum Energy',
+    '2026-09-30',
+    'Unit 12, 28 Logistics Drive',
+    'Erskine Park, 2759, NSW, Australia',
+    20080,
+    47832,
+    75929,
+    143841,
+    'Energy Australia',
+    24,
+    7850,
+    7200,
+    '30 Days',
+    'Net 14'
+);
 
-INSERT INTO invoice (company_id, period, nmi_number, location2, invoice, ex_gst, gst, total) VALUES
-  (1, '2024-01', 'NMI123', 'Warehouse', 'INV-001', 1000.00, 100.00, 1100.00),
-  (1, '2024-02', 'NMI123', 'Warehouse', 'INV-002', 1200.00, 120.00, 1320.00),
-  (2, '2024-01', 'NMI987', 'Office', 'INV-003', 900.00, 90.00, 990.00);
+INSERT INTO contract_offers (
+    report_id,
+    supplier_name,
+    term_months,
+    peak_rate,
+    shoulder_rate,
+    off_peak_rate,
+    total_cost,
+    diff_dollar,
+    diff_percentage
+) VALUES
+    (1, 'Current', 12, 0.093, 0.11071, 0.09319, 14594.36, NULL, NULL),
+    (1, 'Supplier 2', 12, 0.11071, 0.11071, 0.09319, 14594.36, 0.0, 100),
+    (1, 'Supplier 3', 12, 0.11071, 0.11071, 0.09319, 14594.36, 0.0, 100),
+    (1, 'Current', 24, 0.093, 0.11071, 0.09319, 29188.72, NULL, NULL),
+    (1, 'Supplier 2', 24, 0.11071, 0.11071, 0.09319, 29188.72, 14594.36, 200),
+    (1, 'Supplier 3', 24, 0.11071, 0.11071, 0.09319, 29188.72, 14594.36, 200),
+    (1, 'Current', 36, 0.093, 0.11071, 0.09319, 43783.08, NULL, NULL),
+    (1, 'Supplier 2', 36, 0.11071, 0.11071, 0.09319, 43783.08, 29188.72, 200),
+    (1, 'Supplier 3', 36, 0.11071, 0.11071, 0.09319, 43783.08, 29188.72, 300);
+
+INSERT INTO other_costs (report_id, cost_label, cost_amount) VALUES
+    (1, 'Network Costs', 1000.0),
+    (1, 'Cost 2', 1000.0),
+    (1, 'Cost 3', 1000.0);

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Returns a shared PDO connection to the local SQLite database.
+ */
+function getDbConnection(): PDO
+{
+    static $pdo;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $databasePath = __DIR__ . '/../data/centralis.db';
+    $databaseDirectory = dirname($databasePath);
+
+    if (!is_dir($databaseDirectory)) {
+        mkdir($databaseDirectory, 0777, true);
+    }
+
+    $pdo = new PDO('sqlite:' . $databasePath);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+
+    initializeDatabase($pdo);
+
+    return $pdo;
+}
+
+/**
+ * Ensures that the required database tables exist by running the schema.sql file
+ * when the database is empty.
+ */
+function initializeDatabase(PDO $pdo): void
+{
+    $statement = $pdo->query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'reports'");
+    $hasReportsTable = $statement !== false && $statement->fetchColumn() !== false;
+
+    if ($hasReportsTable) {
+        return;
+    }
+
+    $schemaPath = __DIR__ . '/../database/schema.sql';
+    if (!file_exists($schemaPath)) {
+        throw new RuntimeException('Unable to locate database schema at ' . $schemaPath);
+    }
+
+    $schemaSql = file_get_contents($schemaPath);
+    if ($schemaSql === false) {
+        throw new RuntimeException('Unable to read database schema file.');
+    }
+
+    $pdo->exec($schemaSql);
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Removes currency formatting and converts the value to a float.
+ */
+function parseCurrency(?string $value): ?float
+{
+    if ($value === null) {
+        return null;
+    }
+
+    $cleanValue = preg_replace('/[^0-9.\-]/', '', $value);
+
+    if ($cleanValue === '' || $cleanValue === null) {
+        return null;
+    }
+
+    return (float) $cleanValue;
+}
+
+/**
+ * Formats a numeric value as Australian currency.
+ */
+function formatCurrency(?float $amount): string
+{
+    if ($amount === null) {
+        return 'N/A';
+    }
+
+    return '$' . number_format($amount, 2);
+}
+
+/**
+ * Formats a numeric value as kWh with thousands separators.
+ */
+function formatKwh(?float $value): string
+{
+    if ($value === null) {
+        return 'N/A';
+    }
+
+    return number_format($value) . ' kWh';
+}
+
+/**
+ * Formats a number as a percentage string.
+ */
+function formatPercentage(?float $value): string
+{
+    if ($value === null) {
+        return 'N/A';
+    }
+
+    return rtrim(rtrim(number_format($value, 2), '0'), '.') . '%';
+}
+
+/**
+ * Formats a date string from YYYY-MM-DD to `d M Y`.
+ */
+function formatDisplayDate(?string $value): string
+{
+    if (!$value) {
+        return 'N/A';
+    }
+
+    $date = DateTime::createFromFormat('Y-m-d', $value) ?: DateTime::createFromFormat('d/m/Y', $value);
+    if ($date === false) {
+        return $value;
+    }
+
+    return $date->format('d M Y');
+}

--- a/public/create_report.php
+++ b/public/create_report.php
@@ -1,0 +1,407 @@
+<?php
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/helpers.php';
+
+$pdo = getDbConnection();
+
+$formData = [
+    'report_identifier' => '',
+    'report_date' => '',
+    'customer_business_name' => '',
+    'customer_contact_name' => '',
+    'broker_consultant' => '',
+    'site_nmi' => '',
+    'site_current_retailer' => '',
+    'site_contract_end_date' => '',
+    'site_address_line1' => '',
+    'site_address_line2' => '',
+    'site_peak_kwh' => '',
+    'site_shoulder_kwh' => '',
+    'site_off_peak_kwh' => '',
+    'site_total_kwh' => '',
+    'contract_current_retailer' => '',
+    'contract_term_months' => '',
+    'current_cost' => '',
+    'new_cost' => '',
+    'validity_period' => '',
+    'payment_terms' => '',
+];
+
+$contracts = [
+    ['supplier_name' => 'Current', 'term_months' => 12, 'peak_rate' => '', 'shoulder_rate' => '', 'off_peak_rate' => '', 'total_cost' => '', 'diff_dollar' => '', 'diff_percentage' => ''],
+    ['supplier_name' => 'Supplier 2', 'term_months' => 12, 'peak_rate' => '', 'shoulder_rate' => '', 'off_peak_rate' => '', 'total_cost' => '', 'diff_dollar' => '', 'diff_percentage' => ''],
+    ['supplier_name' => 'Supplier 3', 'term_months' => 12, 'peak_rate' => '', 'shoulder_rate' => '', 'off_peak_rate' => '', 'total_cost' => '', 'diff_dollar' => '', 'diff_percentage' => ''],
+];
+
+$otherCosts = [
+    ['cost_label' => 'Network Costs', 'cost_amount' => ''],
+    ['cost_label' => 'Cost 2', 'cost_amount' => ''],
+    ['cost_label' => 'Cost 3', 'cost_amount' => ''],
+];
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    foreach (array_keys($formData) as $key) {
+        $formData[$key] = trim((string)($_POST[$key] ?? ''));
+    }
+
+    $contracts = array_values($_POST['contracts'] ?? $contracts);
+    $otherCosts = array_values($_POST['other_costs'] ?? $otherCosts);
+
+    if ($formData['report_identifier'] === '') {
+        $errors[] = 'Report ID is required.';
+    }
+    if ($formData['customer_business_name'] === '') {
+        $errors[] = 'Customer business name is required.';
+    }
+
+    if (empty($errors)) {
+        $insertReport = $pdo->prepare(
+            'INSERT INTO reports (
+                report_identifier,
+                report_date,
+                customer_business_name,
+                customer_contact_name,
+                broker_consultant,
+                site_nmi,
+                site_current_retailer,
+                site_contract_end_date,
+                site_address_line1,
+                site_address_line2,
+                site_peak_kwh,
+                site_shoulder_kwh,
+                site_off_peak_kwh,
+                site_total_kwh,
+                contract_current_retailer,
+                contract_term_months,
+                current_cost,
+                new_cost,
+                validity_period,
+                payment_terms
+            ) VALUES (
+                :report_identifier,
+                :report_date,
+                :customer_business_name,
+                :customer_contact_name,
+                :broker_consultant,
+                :site_nmi,
+                :site_current_retailer,
+                :site_contract_end_date,
+                :site_address_line1,
+                :site_address_line2,
+                :site_peak_kwh,
+                :site_shoulder_kwh,
+                :site_off_peak_kwh,
+                :site_total_kwh,
+                :contract_current_retailer,
+                :contract_term_months,
+                :current_cost,
+                :new_cost,
+                :validity_period,
+                :payment_terms
+            )'
+        );
+
+        $insertReport->execute([
+            ':report_identifier' => $formData['report_identifier'],
+            ':report_date' => $formData['report_date'] ?: null,
+            ':customer_business_name' => $formData['customer_business_name'],
+            ':customer_contact_name' => $formData['customer_contact_name'] ?: null,
+            ':broker_consultant' => $formData['broker_consultant'] ?: null,
+            ':site_nmi' => $formData['site_nmi'] ?: null,
+            ':site_current_retailer' => $formData['site_current_retailer'] ?: null,
+            ':site_contract_end_date' => $formData['site_contract_end_date'] ?: null,
+            ':site_address_line1' => $formData['site_address_line1'] ?: null,
+            ':site_address_line2' => $formData['site_address_line2'] ?: null,
+            ':site_peak_kwh' => $formData['site_peak_kwh'] !== '' ? (float) str_replace(',', '', $formData['site_peak_kwh']) : null,
+            ':site_shoulder_kwh' => $formData['site_shoulder_kwh'] !== '' ? (float) str_replace(',', '', $formData['site_shoulder_kwh']) : null,
+            ':site_off_peak_kwh' => $formData['site_off_peak_kwh'] !== '' ? (float) str_replace(',', '', $formData['site_off_peak_kwh']) : null,
+            ':site_total_kwh' => $formData['site_total_kwh'] !== '' ? (float) str_replace(',', '', $formData['site_total_kwh']) : null,
+            ':contract_current_retailer' => $formData['contract_current_retailer'] ?: null,
+            ':contract_term_months' => $formData['contract_term_months'] !== '' ? (int) $formData['contract_term_months'] : null,
+            ':current_cost' => parseCurrency($formData['current_cost']),
+            ':new_cost' => parseCurrency($formData['new_cost']),
+            ':validity_period' => $formData['validity_period'] ?: null,
+            ':payment_terms' => $formData['payment_terms'] ?: null,
+        ]);
+
+        $reportId = (int) $pdo->lastInsertId();
+
+        $insertContract = $pdo->prepare(
+            'INSERT INTO contract_offers (
+                report_id,
+                supplier_name,
+                term_months,
+                peak_rate,
+                shoulder_rate,
+                off_peak_rate,
+                total_cost,
+                diff_dollar,
+                diff_percentage
+            ) VALUES (
+                :report_id,
+                :supplier_name,
+                :term_months,
+                :peak_rate,
+                :shoulder_rate,
+                :off_peak_rate,
+                :total_cost,
+                :diff_dollar,
+                :diff_percentage
+            )'
+        );
+
+        foreach ($contracts as $contract) {
+            $supplier = trim((string)($contract['supplier_name'] ?? ''));
+            $term = isset($contract['term_months']) ? (int) $contract['term_months'] : null;
+
+            if ($supplier === '' || !$term) {
+                continue;
+            }
+
+            $insertContract->execute([
+                ':report_id' => $reportId,
+                ':supplier_name' => $supplier,
+                ':term_months' => $term,
+                ':peak_rate' => $contract['peak_rate'] !== '' ? (float) $contract['peak_rate'] : null,
+                ':shoulder_rate' => $contract['shoulder_rate'] !== '' ? (float) $contract['shoulder_rate'] : null,
+                ':off_peak_rate' => $contract['off_peak_rate'] !== '' ? (float) $contract['off_peak_rate'] : null,
+                ':total_cost' => $contract['total_cost'] !== '' ? parseCurrency((string)$contract['total_cost']) : null,
+                ':diff_dollar' => $contract['diff_dollar'] !== '' ? parseCurrency((string)$contract['diff_dollar']) : null,
+                ':diff_percentage' => $contract['diff_percentage'] !== '' ? (float) $contract['diff_percentage'] : null,
+            ]);
+        }
+
+        $insertOtherCost = $pdo->prepare(
+            'INSERT INTO other_costs (report_id, cost_label, cost_amount) VALUES (:report_id, :cost_label, :cost_amount)'
+        );
+
+        foreach ($otherCosts as $otherCost) {
+            $label = trim((string)($otherCost['cost_label'] ?? ''));
+            $amount = isset($otherCost['cost_amount']) ? parseCurrency((string)$otherCost['cost_amount']) : null;
+
+            if ($label === '' || $amount === null) {
+                continue;
+            }
+
+            $insertOtherCost->execute([
+                ':report_id' => $reportId,
+                ':cost_label' => $label,
+                ':cost_amount' => $amount,
+            ]);
+        }
+
+        header('Location: report.php?id=' . $reportId);
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Energy Report</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script>
+        function addContractRow() {
+            const template = document.getElementById('contract-row-template');
+            const container = document.getElementById('contract-rows');
+            const clone = template.content.cloneNode(true);
+            container.appendChild(clone);
+        }
+
+        function addOtherCostRow() {
+            const template = document.getElementById('other-cost-template');
+            const container = document.getElementById('other-cost-rows');
+            const clone = template.content.cloneNode(true);
+            container.appendChild(clone);
+        }
+    </script>
+</head>
+<body>
+<header class="top-bar">
+    <div class="container">
+        <h1>Create Energy Report</h1>
+        <nav>
+            <a class="button" href="index.php">Back to Reports</a>
+        </nav>
+    </div>
+</header>
+
+<main class="container">
+    <section class="card">
+        <?php if (!empty($errors)): ?>
+            <div class="alert alert--error">
+                <ul>
+                    <?php foreach ($errors as $error): ?>
+                        <li><?= htmlspecialchars($error) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+
+        <form method="post" class="form-grid">
+            <h2>Report Details</h2>
+            <label>Report ID
+                <input type="text" name="report_identifier" value="<?= htmlspecialchars($formData['report_identifier']) ?>" required>
+            </label>
+            <label>Report Date
+                <input type="date" name="report_date" value="<?= htmlspecialchars($formData['report_date']) ?>">
+            </label>
+            <label>Customer Business Name
+                <input type="text" name="customer_business_name" value="<?= htmlspecialchars($formData['customer_business_name']) ?>" required>
+            </label>
+            <label>Customer Contact Name
+                <input type="text" name="customer_contact_name" value="<?= htmlspecialchars($formData['customer_contact_name']) ?>">
+            </label>
+            <label>Broker Consultant
+                <input type="text" name="broker_consultant" value="<?= htmlspecialchars($formData['broker_consultant']) ?>">
+            </label>
+
+            <h2>Site Information</h2>
+            <label>NMI
+                <input type="text" name="site_nmi" value="<?= htmlspecialchars($formData['site_nmi']) ?>">
+            </label>
+            <label>Current Retailer
+                <input type="text" name="site_current_retailer" value="<?= htmlspecialchars($formData['site_current_retailer']) ?>">
+            </label>
+            <label>Contract End Date
+                <input type="date" name="site_contract_end_date" value="<?= htmlspecialchars($formData['site_contract_end_date']) ?>">
+            </label>
+            <label>Supply Address Line 1
+                <input type="text" name="site_address_line1" value="<?= htmlspecialchars($formData['site_address_line1']) ?>">
+            </label>
+            <label>Supply Address Line 2
+                <input type="text" name="site_address_line2" value="<?= htmlspecialchars($formData['site_address_line2']) ?>">
+            </label>
+            <label>Peak kWh
+                <input type="number" step="1" name="site_peak_kwh" value="<?= htmlspecialchars($formData['site_peak_kwh']) ?>">
+            </label>
+            <label>Shoulder kWh
+                <input type="number" step="1" name="site_shoulder_kwh" value="<?= htmlspecialchars($formData['site_shoulder_kwh']) ?>">
+            </label>
+            <label>Off Peak kWh
+                <input type="number" step="1" name="site_off_peak_kwh" value="<?= htmlspecialchars($formData['site_off_peak_kwh']) ?>">
+            </label>
+            <label>Total kWh
+                <input type="number" step="1" name="site_total_kwh" value="<?= htmlspecialchars($formData['site_total_kwh']) ?>">
+            </label>
+
+            <h2>Current Contract</h2>
+            <label>Current Retailer
+                <input type="text" name="contract_current_retailer" value="<?= htmlspecialchars($formData['contract_current_retailer']) ?>">
+            </label>
+            <label>Term (months)
+                <input type="number" step="1" name="contract_term_months" value="<?= htmlspecialchars($formData['contract_term_months']) ?>">
+            </label>
+            <label>Current Cost
+                <input type="text" name="current_cost" value="<?= htmlspecialchars($formData['current_cost']) ?>">
+            </label>
+            <label>New Cost
+                <input type="text" name="new_cost" value="<?= htmlspecialchars($formData['new_cost']) ?>">
+            </label>
+            <label>Validity Period
+                <input type="text" name="validity_period" value="<?= htmlspecialchars($formData['validity_period']) ?>">
+            </label>
+            <label>Payment Terms
+                <input type="text" name="payment_terms" value="<?= htmlspecialchars($formData['payment_terms']) ?>">
+            </label>
+
+            <h2>Contract Offers</h2>
+            <div class="table-scroll">
+                <table class="data-table">
+                    <thead>
+                    <tr>
+                        <th>Supplier</th>
+                        <th>Term (months)</th>
+                        <th>Peak Rate</th>
+                        <th>Shoulder Rate</th>
+                        <th>Off Peak Rate</th>
+                        <th>Total Cost</th>
+                        <th>$ Diff</th>
+                        <th>% Diff</th>
+                    </tr>
+                    </thead>
+                    <tbody id="contract-rows">
+                    <?php foreach ($contracts as $index => $contract): ?>
+                        <tr>
+                            <td><input type="text" name="contracts[<?= $index ?>][supplier_name]" value="<?= htmlspecialchars($contract['supplier_name'] ?? '') ?>"></td>
+                            <td>
+                                <select name="contracts[<?= $index ?>][term_months]">
+                                    <option value="">Select</option>
+                                    <?php foreach ([12, 24, 36] as $term): ?>
+                                        <option value="<?= $term ?>" <?= isset($contract['term_months']) && (int)$contract['term_months'] === $term ? 'selected' : '' ?>><?= $term ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </td>
+                            <td><input type="number" step="0.00001" name="contracts[<?= $index ?>][peak_rate]" value="<?= htmlspecialchars($contract['peak_rate'] ?? '') ?>"></td>
+                            <td><input type="number" step="0.00001" name="contracts[<?= $index ?>][shoulder_rate]" value="<?= htmlspecialchars($contract['shoulder_rate'] ?? '') ?>"></td>
+                            <td><input type="number" step="0.00001" name="contracts[<?= $index ?>][off_peak_rate]" value="<?= htmlspecialchars($contract['off_peak_rate'] ?? '') ?>"></td>
+                            <td><input type="text" name="contracts[<?= $index ?>][total_cost]" value="<?= htmlspecialchars($contract['total_cost'] ?? '') ?>"></td>
+                            <td><input type="text" name="contracts[<?= $index ?>][diff_dollar]" value="<?= htmlspecialchars($contract['diff_dollar'] ?? '') ?>"></td>
+                            <td><input type="number" step="0.01" name="contracts[<?= $index ?>][diff_percentage]" value="<?= htmlspecialchars($contract['diff_percentage'] ?? '') ?>"></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+            <button type="button" class="button" onclick="addContractRow()">Add Contract Offer</button>
+
+            <h2>Other Costs</h2>
+            <div class="table-scroll">
+                <table class="data-table">
+                    <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th>Amount</th>
+                    </tr>
+                    </thead>
+                    <tbody id="other-cost-rows">
+                    <?php foreach ($otherCosts as $index => $otherCost): ?>
+                        <tr>
+                            <td><input type="text" name="other_costs[<?= $index ?>][cost_label]" value="<?= htmlspecialchars($otherCost['cost_label'] ?? '') ?>"></td>
+                            <td><input type="text" name="other_costs[<?= $index ?>][cost_amount]" value="<?= htmlspecialchars($otherCost['cost_amount'] ?? '') ?>"></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+            <button type="button" class="button" onclick="addOtherCostRow()">Add Other Cost</button>
+
+            <div class="form-actions">
+                <button type="submit" class="button button--primary">Save Report</button>
+            </div>
+        </form>
+    </section>
+</main>
+
+<template id="contract-row-template">
+    <tr>
+        <td><input type="text" name="contracts[][supplier_name]"></td>
+        <td>
+            <select name="contracts[][term_months]">
+                <option value="">Select</option>
+                <option value="12">12</option>
+                <option value="24">24</option>
+                <option value="36">36</option>
+            </select>
+        </td>
+        <td><input type="number" step="0.00001" name="contracts[][peak_rate]"></td>
+        <td><input type="number" step="0.00001" name="contracts[][shoulder_rate]"></td>
+        <td><input type="number" step="0.00001" name="contracts[][off_peak_rate]"></td>
+        <td><input type="text" name="contracts[][total_cost]"></td>
+        <td><input type="text" name="contracts[][diff_dollar]"></td>
+        <td><input type="number" step="0.01" name="contracts[][diff_percentage]"></td>
+    </tr>
+</template>
+
+<template id="other-cost-template">
+    <tr>
+        <td><input type="text" name="other_costs[][cost_label]"></td>
+        <td><input type="text" name="other_costs[][cost_amount]"></td>
+    </tr>
+</template>
+
+</body>
+</html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,245 @@
+:root {
+    --primary: #1f4d7a;
+    --accent: #f5a623;
+    --background: #f5f7fa;
+    --text: #1f2933;
+    --muted: #52606d;
+    --border: #d2d6dc;
+    --white: #ffffff;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--background);
+    color: var(--text);
+}
+
+.container {
+    width: min(1100px, 95vw);
+    margin: 0 auto;
+    padding: 1.5rem 0;
+}
+
+.top-bar {
+    background: var(--primary);
+    color: var(--white);
+    padding: 1rem 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.top-bar h1 {
+    margin: 0;
+    font-size: 1.6rem;
+}
+
+.top-bar nav {
+    margin-top: 0.5rem;
+}
+
+.top-bar .button {
+    background: var(--accent);
+    color: var(--white);
+}
+
+.footer {
+    text-align: center;
+    padding: 2rem 0;
+    color: var(--muted);
+}
+
+.card {
+    background: var(--white);
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+    margin-top: 0;
+}
+
+.button {
+    display: inline-block;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--primary);
+    color: var(--white);
+    text-decoration: none;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
+}
+
+.button:hover {
+    background: #16354f;
+}
+
+.button--primary {
+    background: var(--accent);
+}
+
+.button--primary:hover {
+    background: #cc840e;
+}
+
+.button--link {
+    background: transparent;
+    color: var(--primary);
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--primary);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.data-table th,
+.data-table td {
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    white-space: nowrap;
+}
+
+.data-table th {
+    background: #f0f4f8;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+
+.data-table tbody tr:nth-child(even) {
+    background: #fafbfc;
+}
+
+.table-scroll {
+    overflow-x: auto;
+}
+
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+    padding: 0.6rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    font-size: 1rem;
+}
+
+.form-actions {
+    margin-top: 1.5rem;
+}
+
+.alert {
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.alert--error {
+    background: #fde2e1;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+}
+
+.report__header {
+    background: linear-gradient(135deg, var(--primary), #122b45);
+    color: var(--white);
+    padding: 2.5rem 0;
+}
+
+.report__summary {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 2rem;
+}
+
+.report__summary h1 {
+    margin-bottom: 0.3rem;
+}
+
+.consultant {
+    text-align: right;
+}
+
+.consultant__name {
+    font-size: 1.3rem;
+    font-weight: 700;
+}
+
+.report__content h3 {
+    margin-top: 2rem;
+}
+
+.grid {
+    display: grid;
+    gap: 2rem;
+}
+
+.grid.two-columns {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+dl {
+    margin: 0;
+}
+
+dl dt {
+    font-weight: 700;
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+}
+
+dl dd {
+    margin: 0 0 1rem 0;
+    font-size: 1rem;
+}
+
+.disclaimer {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+
+.report ol {
+    padding-left: 1.25rem;
+    line-height: 1.6;
+}
+
+@media print {
+    body {
+        background: #ffffff;
+    }
+
+    .top-bar,
+    .button,
+    .footer {
+        display: none;
+    }
+
+    .card {
+        box-shadow: none;
+        border: 1px solid #e5e7eb;
+        page-break-inside: avoid;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../includes/db.php';
+
+$pdo = getDbConnection();
+
+$statement = $pdo->query('SELECT id, report_identifier, customer_business_name, report_date FROM reports ORDER BY created_at DESC');
+$reports = $statement ? $statement->fetchAll(PDO::FETCH_ASSOC) : [];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Centralis Energy Reports</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header class="top-bar">
+    <div class="container">
+        <h1>Centralis Energy Reports</h1>
+        <nav>
+            <a class="button" href="create_report.php">Create Report</a>
+        </nav>
+    </div>
+</header>
+
+<main class="container">
+    <section class="card">
+        <h2>Existing Reports</h2>
+        <?php if (empty($reports)): ?>
+            <p>No reports have been created yet. <a href="create_report.php">Create your first report</a>.</p>
+        <?php else: ?>
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Business Name</th>
+                        <th>Report Date</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($reports as $report): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($report['report_identifier']) ?></td>
+                        <td><?= htmlspecialchars($report['customer_business_name']) ?></td>
+                        <td><?= htmlspecialchars($report['report_date']) ?></td>
+                        <td><a class="button button--link" href="report.php?id=<?= urlencode($report['id']) ?>">View</a></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="container">
+        <p>&copy; <?= date('Y') ?> Centralis</p>
+    </div>
+</footer>
+</body>
+</html>

--- a/public/report.php
+++ b/public/report.php
@@ -1,0 +1,211 @@
+<?php
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/helpers.php';
+
+$pdo = getDbConnection();
+
+$reportId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+
+$reportQuery = $pdo->prepare('SELECT * FROM reports WHERE id = :id');
+$reportQuery->execute([':id' => $reportId]);
+$report = $reportQuery->fetch(PDO::FETCH_ASSOC);
+
+if (!$report) {
+    http_response_code(404);
+    echo '<p>Report not found.</p>';
+    exit;
+}
+
+$contractsQuery = $pdo->prepare('SELECT * FROM contract_offers WHERE report_id = :id ORDER BY term_months, supplier_name');
+$contractsQuery->execute([':id' => $reportId]);
+$contracts = $contractsQuery->fetchAll(PDO::FETCH_ASSOC);
+
+$otherCostsQuery = $pdo->prepare('SELECT cost_label, cost_amount FROM other_costs WHERE report_id = :id');
+$otherCostsQuery->execute([':id' => $reportId]);
+$otherCosts = $otherCostsQuery->fetchAll(PDO::FETCH_ASSOC);
+
+$contractsByTerm = [];
+foreach ($contracts as $contract) {
+    $contractsByTerm[(int) $contract['term_months']][] = $contract;
+}
+
+$termHeadings = [
+    12 => '12 MONTH OFFERS',
+    24 => '24 MONTH OFFERS',
+    36 => '36 MONTH OFFERS',
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Energy Report <?= htmlspecialchars($report['report_identifier']) ?></title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="report">
+<header class="report__header">
+    <div class="container">
+        <p class="disclaimer">Prices are indicative only.</p>
+        <div class="report__summary">
+            <div>
+                <h1>Energy Price Comparison</h1>
+                <p>For <?= htmlspecialchars($report['customer_business_name']) ?></p>
+                <p><?= htmlspecialchars(formatDisplayDate($report['report_date'])) ?></p>
+            </div>
+            <div class="consultant">
+                <p class="consultant__name"><?= htmlspecialchars($report['broker_consultant'] ?: 'Your Consultant') ?></p>
+                <p>1300 380 749</p>
+            </div>
+        </div>
+    </div>
+</header>
+
+<main class="container report__content">
+    <section class="card">
+        <p class="disclaimer">Prices are indicative only.</p>
+        <h2>Customer Profile</h2>
+        <div class="grid two-columns">
+            <div>
+                <h3>Business Information</h3>
+                <dl>
+                    <dt>Business Name</dt>
+                    <dd><?= htmlspecialchars($report['customer_business_name']) ?></dd>
+                    <dt>Contact Name</dt>
+                    <dd><?= htmlspecialchars($report['customer_contact_name'] ?? 'N/A') ?></dd>
+                    <dt>Energy Consultant</dt>
+                    <dd><?= htmlspecialchars($report['broker_consultant'] ?? 'N/A') ?></dd>
+                </dl>
+            </div>
+            <div>
+                <h3>Site Information</h3>
+                <dl>
+                    <dt>Current Retailer</dt>
+                    <dd><?= htmlspecialchars($report['site_current_retailer'] ?? 'N/A') ?></dd>
+                    <dt>Contract End Date</dt>
+                    <dd><?= htmlspecialchars(formatDisplayDate($report['site_contract_end_date'])) ?></dd>
+                    <dt>NMI</dt>
+                    <dd><?= htmlspecialchars($report['site_nmi'] ?? 'N/A') ?></dd>
+                    <dt>Supply Address</dt>
+                    <dd>
+                        <?= nl2br(htmlspecialchars(trim(($report['site_address_line1'] ?? '') . "\n" . ($report['site_address_line2'] ?? '')))) ?>
+                    </dd>
+                </dl>
+            </div>
+        </div>
+
+        <div class="grid two-columns">
+            <div>
+                <h3>Current Retailer</h3>
+                <dl>
+                    <dt>Current Retailer</dt>
+                    <dd><?= htmlspecialchars($report['contract_current_retailer'] ?? 'N/A') ?></dd>
+                    <dt>Term</dt>
+                    <dd><?= htmlspecialchars($report['contract_term_months'] !== null ? $report['contract_term_months'] . ' Months' : 'N/A') ?></dd>
+                    <dt>Current</dt>
+                    <dd><?= htmlspecialchars(formatCurrency($report['current_cost'] !== null ? (float) $report['current_cost'] : null)) ?></dd>
+                    <dt>New</dt>
+                    <dd><?= htmlspecialchars(formatCurrency($report['new_cost'] !== null ? (float) $report['new_cost'] : null)) ?></dd>
+                    <dt>Validity Period</dt>
+                    <dd><?= htmlspecialchars($report['validity_period'] ?? 'N/A') ?></dd>
+                    <dt>Payment Terms</dt>
+                    <dd><?= htmlspecialchars($report['payment_terms'] ?? 'N/A') ?></dd>
+                </dl>
+            </div>
+            <div>
+                <h3>Energy Consumption</h3>
+                <dl>
+                    <dt>Peak</dt>
+                    <dd><?= htmlspecialchars(formatKwh($report['site_peak_kwh'] !== null ? (float) $report['site_peak_kwh'] : null)) ?></dd>
+                    <dt>Shoulder</dt>
+                    <dd><?= htmlspecialchars(formatKwh($report['site_shoulder_kwh'] !== null ? (float) $report['site_shoulder_kwh'] : null)) ?></dd>
+                    <dt>Off Peak</dt>
+                    <dd><?= htmlspecialchars(formatKwh($report['site_off_peak_kwh'] !== null ? (float) $report['site_off_peak_kwh'] : null)) ?></dd>
+                    <dt>Total</dt>
+                    <dd><?= htmlspecialchars(formatKwh($report['site_total_kwh'] !== null ? (float) $report['site_total_kwh'] : null)) ?></dd>
+                </dl>
+            </div>
+        </div>
+    </section>
+
+    <section class="card">
+        <p class="disclaimer">Prices are indicative only.</p>
+        <h2>Price Comparison</h2>
+
+        <?php foreach ($termHeadings as $term => $heading): ?>
+            <?php if (!isset($contractsByTerm[$term])) { continue; } ?>
+            <h3><?= $heading ?></h3>
+            <div class="table-scroll">
+                <table class="data-table">
+                    <thead>
+                    <tr>
+                        <th>Supplier</th>
+                        <th>P</th>
+                        <th>S</th>
+                        <th>O</th>
+                        <th>Total Costs</th>
+                        <th>$ Diff</th>
+                        <th>% Diff</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($contractsByTerm[$term] as $contract): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($contract['supplier_name']) ?></td>
+                            <td><?= htmlspecialchars($contract['peak_rate'] !== null ? number_format((float)$contract['peak_rate'], 3) : 'N/A') ?></td>
+                            <td><?= htmlspecialchars($contract['shoulder_rate'] !== null ? number_format((float)$contract['shoulder_rate'], 3) : 'N/A') ?></td>
+                            <td><?= htmlspecialchars($contract['off_peak_rate'] !== null ? number_format((float)$contract['off_peak_rate'], 3) : 'N/A') ?></td>
+                            <td><?= htmlspecialchars(formatCurrency($contract['total_cost'] !== null ? (float)$contract['total_cost'] : null)) ?></td>
+                            <td><?= htmlspecialchars($contract['diff_dollar'] !== null ? formatCurrency((float)$contract['diff_dollar']) : 'N/A') ?></td>
+                            <td><?= htmlspecialchars($contract['diff_percentage'] !== null ? formatPercentage((float)$contract['diff_percentage']) : 'N/A') ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endforeach; ?>
+
+        <?php if (!empty($otherCosts)): ?>
+            <h3>Other Costs</h3>
+            <div class="table-scroll">
+                <table class="data-table">
+                    <thead>
+                    <tr>
+                        <th>Charges</th>
+                        <th>Cost</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($otherCosts as $cost): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($cost['cost_label']) ?></td>
+                            <td><?= htmlspecialchars(formatCurrency((float)$cost['cost_amount'])) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </section>
+
+    <section class="card">
+        <p class="disclaimer">Prices are indicative only.</p>
+        <h2>Next Steps / Actions</h2>
+        <ol>
+            <li>Secure the chosen retailer’s energy agreement.</li>
+            <li>Validate offer to ensure accuracy in energy rates and terms.</li>
+            <li>Supply a digital copy via DocuSign.</li>
+            <li>Submit signed agreement to retailer.</li>
+            <li>Confirm contract acceptance.</li>
+            <li>Manage transfer process.</li>
+        </ol>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="container">
+        <p class="disclaimer">Prices are indicative only.</p>
+        <p>&copy; <?= date('Y') ?> Centralis</p>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SQLite schema, seed data, and helper utilities to support energy price comparison reports
- create PHP pages for listing, creating, and rendering printable energy reports from stored data
- style the application and document how to run the development server

## Testing
- php -l public/index.php
- php -l public/create_report.php
- php -l public/report.php
- php -l includes/db.php
- php -l includes/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68e64b05b12883268d6f069d0a3569a7